### PR TITLE
Add defines enabling use of PORTA or PORTB pins on ATtiny84

### DIFF
--- a/src/ATtinySerialOut.hpp
+++ b/src/ATtinySerialOut.hpp
@@ -70,6 +70,17 @@
 #define TX_PORT_ADDR 0x0B // PORTD
 #define TX_DDR DDRD
 
+#elif defined(__AVR_ATtiny84__)
+#  if defined(USE_PORTA_FOR_TX_PIN)
+#define TX_PORT PORTA
+#define TX_PORT_ADDR 0x1B
+#define TX_DDR DDRA
+#  else
+#define TX_PORT PORTB
+#define TX_PORT_ADDR 0x18
+#define TX_DDR DDRB
+#  endif
+
 #else
 //  ATtinyX5 here
 #define TX_PORT PORTB


### PR DESCRIPTION
This was literally the library I was looking for very hard just now, and nice work on the minimal flash usage, lovely.

However I wanted to use a pin on PORTA, but currently PORTB register definitions/addresses are used by default, so...

The ATtiny84 has two ports, add support for using PORTA pins in addition to the default PORTB register definitions used previously.